### PR TITLE
CI: force actions to run on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ concurrency:
   group: 'pages'
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     environment:


### PR DESCRIPTION
Esse PR tem por objetivo forçar o uso do Node 24 para resolver o seguinte warning no workflow:

<img width="1424" height="262" alt="image" src="https://github.com/user-attachments/assets/7de3fd76-04f6-4f53-aa6c-1162b5bef537" />
