### PR TITLE
fix: Evita o ocultamento do menu Mobile quando scrolla

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ function Header() {
             </nav>
             {/* Mobile Menu */}
             {openMenu && (
-                <nav className="flex flex-col md:hidden bg-furg-yellow h-dvh fixed inset-0 overflow-hidden">
+                <nav className="flex flex-col md:hidden bg-furg-yellow h-dvh fixed top-0 inset-x-0 overflow-hidden">
                     <button className="cursor-pointer flex justify-end p-4" onClick={() => setOpenMenu(false)}>
                         <X />
                     </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,13 +26,25 @@ function Header() {
                 setIsScrolled(false);
             }
         }
-
+    
         window.addEventListener('scroll', handleScroll);
 
         return () => {
             window.removeEventListener('scroll', handleScroll);
         };
     }, []);
+
+    useEffect(() => {
+        if (openMenu) {
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = "";
+        }
+
+        return () => {
+            document.body.style.overflow = "";
+        };
+    }, [openMenu]);
 
     return (
         <header className={`${isScrolled ? "bg-transparent" : "bg-furg-yellow"} transition duration-300 sticky top-0 flex items-center w-full h-14 p-3 shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1)] justify-between`}>
@@ -51,7 +63,7 @@ function Header() {
             </nav>
             {/* Mobile Menu */}
             {openMenu && (
-                <nav className="flex flex-col md:hidden bg-furg-yellow h-dvh fixed top-0 inset-x-0 overflow-hidden">
+                <nav className="flex flex-col md:hidden bg-furg-yellow fixed inset-0 overflow-y-auto">
                     <button className="cursor-pointer flex justify-end p-4" onClick={() => setOpenMenu(false)}>
                         <X />
                     </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -51,7 +51,7 @@ function Header() {
             </nav>
             {/* Mobile Menu */}
             {openMenu && (
-                <nav className="flex flex-col md:hidden bg-furg-yellow fixed inset-0 overflow-hidden">
+                <nav className="flex flex-col md:hidden bg-furg-yellow h-dvh fixed inset-0 overflow-hidden">
                     <button className="cursor-pointer flex justify-end p-4" onClick={() => setOpenMenu(false)}>
                         <X />
                     </button>


### PR DESCRIPTION
Esse PR foca em resolver o problema do estado transparente do Header após scrollar esconder o conteúdo do menu de navegação Mobile quando aberto. A solução aplicada foi definir a altura do menu para 100% do viewport dinâmico, com a classe `h-dvh`. Isso garante que mesmo com `overflow-hidden`, o menu ocupe a tela inteira, independente da transparência do Header.