### PR TITLE
fix(mobile-menu): Mantém o menu mobile visível mesmo com backdrop-blur definido no Header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -63,7 +63,7 @@ function Header() {
             </nav>
             {/* Mobile Menu */}
             {openMenu && (
-                <nav className="flex flex-col md:hidden bg-furg-yellow fixed inset-0 overflow-y-auto">
+                <nav className="flex flex-col md:hidden bg-furg-yellow h-dvh fixed inset-x-0 top-0 overflow-y-auto">
                     <button className="cursor-pointer flex justify-end p-4" onClick={() => setOpenMenu(false)}>
                         <X />
                     </button>


### PR DESCRIPTION
Esse PR faz uma pequena melhoria de UI no menu mobile do componente Header. Essa mudança garante que o menu use todo espaço vertical disponível na tela e fique visível em todos dispositivos móveis mesmo após scrollar a tela, de maneira que mantém os visuais do Header e a usabilidade do menu.

* Layout de Menu Mobile melhorado:
  * Em `Header.tsx`, agora o menu mobile possui a classe `h-dvh`, que configura sua altura vertical para ocupar todo espaço em tela e evita que ele dependa do tamanho do Header para ser exibido. 